### PR TITLE
Update for Cucumber compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ class WebdriverAjax {
     this._wdajaxExpectations = [];
   }
 
+  beforeScenario() {
+    this._wdajaxExpectations = [];
+  }
+  
   before() {
     /**
      * instance need to have addCommand method


### PR DESCRIPTION
In Cucumber, the `beforeTest()` hook is not used. When we try using the interceptor service in Cucumber, because the `beforeTest()` isn’t being called, the `_wdajaxExpectations` isn’t being assigned to an empty array, therefore we get the error `Cannot read property 'push' of null` because the `_wdajaxExpectations` is still a null at that point. 

This just adds a `beforeScenario()` hook where we assign it the same way we do in `beforeTest()` so it works with Cucumber.