### PR TITLE
Override request.url/body/method only when init values are defined

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -49,10 +49,10 @@ var interceptor = {
           request.method = clonedRequest.method;
         }
         if (init) {
-          request.requestBody = init.body;
-          request.url = init.url;
+          request.requestBody = (init.body) ? init.body:request.requestBody;
+          request.url = (init.url) ? init.url:request.url;
           request.requestHeaders = parseHeaders(init.headers);
-          request.method = init.method;
+          request.method = (init.method) ? init.method : request.method;
         }
 
         return _fetch.apply(window, arguments).then(function(response) {


### PR DESCRIPTION
Fixed #51 . 
In some cases,  URL/Method and body return by getRequests() are 'undefined' due to init values that are 'undefined'.  I propose to override these values only when a value is defined. 
@chmanie, please review my PR .
I need this bug fix, because currently, I can't use expectRequest feature. 