### PR TITLE
Add option to validate only expected requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ class WebdriverAjax {
     browser.addCommand('setupInterceptor', setup.bind(this));
     browser.addCommand('expectRequest', expectRequest.bind(this));
     browser.addCommand('assertRequests', assertRequests.bind(this));
+    browser.addCommand(
+      'assertExpectedRequestsOnly',
+      assertExpectedRequestsOnly.bind(this)
+    );
     browser.addCommand('getRequest', getRequest);
     browser.addCommand('getRequests', getRequest);
 
@@ -123,6 +127,74 @@ class WebdriverAjax {
               )
             );
           }
+        }
+
+        return browser;
+      });
+    }
+
+    function assertExpectedRequestsOnly(inOrder = true) {
+      const expectations = this._wdajaxExpectations;
+
+      return getRequest().then(requests => {
+        const clonedRequests = [...requests];
+
+        let matchedRequestIndexes = [];
+        for (let i = 0; i < expectations.length; i++) {
+          const ex = expectations[i];
+
+          const matchingRequestIndex = clonedRequests.findIndex(request => {
+            if (
+              !request ||
+              request.method !== ex.method ||
+              (ex.url instanceof RegExp &&
+                request.url &&
+                !request.url.match(ex.url)) ||
+              (typeof ex.url == 'string' && request.url !== ex.url) ||
+              request.response.statusCode !== ex.statusCode
+            ) {
+              return false;
+            }
+
+            return true;
+          });
+
+          if (matchingRequestIndex !== undefined) {
+            matchedRequestIndexes.push(matchingRequestIndex);
+            delete clonedRequests[matchingRequestIndex];
+          } else {
+            return Promise.reject(
+              new Error(
+                'Expected request was not found. ' +
+                  'method: ' +
+                  ex.method +
+                  ' url: ' +
+                  ex.url +
+                  ' statusCode: ' +
+                  ex.statusCode
+              )
+            );
+          }
+        }
+
+        if (matchedRequestIndexes.length !== expectations.length) {
+          return Promise.reject(
+            new Error(
+              'Expected ' +
+                expectations.length +
+                ' requests but found ' +
+                matchedRequestIndexes.length +
+                ' matching requests'
+            )
+          );
+        } else if (
+          inOrder &&
+          JSON.stringify(matchedRequestIndexes) !==
+            JSON.stringify(matchedRequestIndexes.concat().sort())
+        ) {
+          return Promise.reject(
+            new Error('Requests not received in the expected order')
+          );
         }
 
         return browser;

--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ class WebdriverAjax {
     }
 
     browser.addCommand('setupInterceptor', setup.bind(this));
+    browser.addCommand('getExpectations', getExpectations.bind(this));
+    browser.addCommand('resetExpectations', resetExpectations.bind(this));
     browser.addCommand('expectRequest', expectRequest.bind(this));
     browser.addCommand('assertRequests', assertRequests.bind(this));
     browser.addCommand(
@@ -199,6 +201,16 @@ class WebdriverAjax {
 
         return browser;
       });
+    }
+
+    // In a long test, it's possible you might want to reset the list
+    // of expected requests after validating some.
+    function resetExpectations() {
+      this._wdajaxExpectations = [];
+    }
+
+    function getExpectations() {
+      return this._wdajaxExpectations;
     }
 
     async function getRequest(index) {

--- a/test/site/multiple_methods.html
+++ b/test/site/multiple_methods.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Get with multiple request methods</title>
+</head>
+<body>
+<p id="text">This file makes ajax requests to different endpoints</p>
+<button id="getbutton">Press me for GET!</button>
+<button id="postbutton">Press me for POST!</button>
+<script>
+    'use strict';
+
+    (function (window, document) {
+
+        var button = document.querySelector('#getbutton');
+        button.addEventListener('click', function (evt) {
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', '/get.json');
+            xhr.send();
+        });
+
+        var fetchButton = document.querySelector('#postbutton');
+        fetchButton.addEventListener('click', function (evt) {
+            var xhr = new XMLHttpRequest();
+            var form = new FormData();
+            form.append('foo', 'bar');
+            xhr.open('POST', '/post.json');
+            var payload = form;
+            xhr.send(payload);
+        });
+
+    })(window, window.document);
+</script>
+</body>
+</html>

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -17,6 +17,17 @@ describe('webdriverajax', function testSuite() {
     assert.deepEqual(ret, { requests: [] });
   });
 
+  it('should reset expectations', () => {
+    assert.equal(typeof browser.setupInterceptor, 'function');
+    browser.url('/get.html');
+    browser.setupInterceptor();
+    browser.expectRequest('GET', '/get.json', 200);
+    browser.expectRequest('GET', '/get.json', 200);
+    assert.equal(browser.getExpectations().length, 2);
+    browser.resetExpectations();
+    assert.equal(browser.getExpectations().length, 0);
+  });
+
   describe('XHR API', () => {
     it('can intercept a simple GET request', () => {
       browser.url('/get.html');
@@ -222,64 +233,64 @@ describe('webdriverajax', function testSuite() {
       assert.deepEqual(count, []);
     });
 
-      it('can validate only the expected requests, in order (implicit)', () => {
-          browser.url('/multiple_methods.html');
-          browser.setupInterceptor();
-          browser.expectRequest('GET', '/get.json', 200);
-          browser.expectRequest('POST', '/post.json', 200);
-          $('#getbutton').click();
-          browser.pause(wait);
-          $('#postbutton').click();
-          browser.pause(wait);
-          // The next two are not needed, but adding extra clicks to prove we can validate partial set
-          $('#getbutton').click();
-          browser.pause(wait);
-          $('#postbutton').click();
-          browser.pause(wait);
-          browser.assertExpectedRequestsOnly();
-          assert.throws(() => {
-              browser.assertRequests();
-          }, /Expected\s\d\srequests\sbut\swas\s\d/);
-      });
+    it('can validate only the expected requests, in order (implicit)', () => {
+      browser.url('/multiple_methods.html');
+      browser.setupInterceptor();
+      browser.expectRequest('GET', '/get.json', 200);
+      browser.expectRequest('POST', '/post.json', 200);
+      $('#getbutton').click();
+      browser.pause(wait);
+      $('#postbutton').click();
+      browser.pause(wait);
+      // The next two are not needed, but adding extra clicks to prove we can validate partial set
+      $('#getbutton').click();
+      browser.pause(wait);
+      $('#postbutton').click();
+      browser.pause(wait);
+      browser.assertExpectedRequestsOnly();
+      assert.throws(() => {
+        browser.assertRequests();
+      }, /Expected\s\d\srequests\sbut\swas\s\d/);
+    });
 
-      it('can validate only the expected requests, in order (explicit)', () => {
-          browser.url('/multiple_methods.html');
-          browser.setupInterceptor();
-          browser.expectRequest('GET', '/get.json', 200);
-          browser.expectRequest('POST', '/post.json', 200);
-          $('#getbutton').click();
-          browser.pause(wait);
-          $('#postbutton').click();
-          browser.pause(wait);
-          // The next two are not needed, but adding extra clicks to prove we can validate partial set
-          $('#getbutton').click();
-          browser.pause(wait);
-          $('#postbutton').click();
-          browser.pause(wait);
-          browser.assertExpectedRequestsOnly(true);
-          assert.throws(() => {
-              browser.assertRequests();
-          }, /Expected\s\d\srequests\sbut\swas\s\d/);
-      });
+    it('can validate only the expected requests, in order (explicit)', () => {
+      browser.url('/multiple_methods.html');
+      browser.setupInterceptor();
+      browser.expectRequest('GET', '/get.json', 200);
+      browser.expectRequest('POST', '/post.json', 200);
+      $('#getbutton').click();
+      browser.pause(wait);
+      $('#postbutton').click();
+      browser.pause(wait);
+      // The next two are not needed, but adding extra clicks to prove we can validate partial set
+      $('#getbutton').click();
+      browser.pause(wait);
+      $('#postbutton').click();
+      browser.pause(wait);
+      browser.assertExpectedRequestsOnly(true);
+      assert.throws(() => {
+        browser.assertRequests();
+      }, /Expected\s\d\srequests\sbut\swas\s\d/);
+    });
 
-      it('can validate only the expected requests, in any order', () => {
-          browser.url('/multiple_methods.html');
-          browser.setupInterceptor();
-          browser.expectRequest('GET', '/get.json', 200);
-          browser.expectRequest('POST', '/post.json', 200);
-          $('#postbutton').click();
-          browser.pause(wait);
-          $('#postbutton').click();
-          browser.pause(wait);
-          $('#getbutton').click();
-          browser.pause(wait);
-          $('#getbutton').click();
-          browser.pause(wait);
-          browser.assertExpectedRequestsOnly(false);
-          assert.throws(() => {
-              browser.assertRequests();
-          }, /Expected\s\d\srequests\sbut\swas\s\d/);
-      });
+    it('can validate only the expected requests, in any order', () => {
+      browser.url('/multiple_methods.html');
+      browser.setupInterceptor();
+      browser.expectRequest('GET', '/get.json', 200);
+      browser.expectRequest('POST', '/post.json', 200);
+      $('#postbutton').click();
+      browser.pause(wait);
+      $('#postbutton').click();
+      browser.pause(wait);
+      $('#getbutton').click();
+      browser.pause(wait);
+      $('#getbutton').click();
+      browser.pause(wait);
+      browser.assertExpectedRequestsOnly(false);
+      assert.throws(() => {
+        browser.assertRequests();
+      }, /Expected\s\d\srequests\sbut\swas\s\d/);
+    });
   });
 
   describe('fetch API', () => {

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -25,6 +25,7 @@ describe('webdriverajax', function testSuite() {
       $('#button').click();
       browser.pause(wait);
       browser.assertRequests();
+      browser.assertExpectedRequestsOnly();
     });
 
     it('can use regular expressions for urls', () => {
@@ -34,6 +35,7 @@ describe('webdriverajax', function testSuite() {
       $('#button').click();
       browser.pause(wait);
       browser.assertRequests();
+      browser.assertExpectedRequestsOnly();
     });
 
     it('errors on wrong request count', () => {
@@ -202,6 +204,7 @@ describe('webdriverajax', function testSuite() {
       $('#button').click();
       browser.pause(wait);
       browser.assertRequests();
+      browser.assertExpectedRequestsOnly();
     });
 
     it('errors with no requests set up', () => {
@@ -218,6 +221,65 @@ describe('webdriverajax', function testSuite() {
       const count = browser.getRequests();
       assert.deepEqual(count, []);
     });
+
+      it('can validate only the expected requests, in order (implicit)', () => {
+          browser.url('/multiple_methods.html');
+          browser.setupInterceptor();
+          browser.expectRequest('GET', '/get.json', 200);
+          browser.expectRequest('POST', '/post.json', 200);
+          $('#getbutton').click();
+          browser.pause(wait);
+          $('#postbutton').click();
+          browser.pause(wait);
+          // The next two are not needed, but adding extra clicks to prove we can validate partial set
+          $('#getbutton').click();
+          browser.pause(wait);
+          $('#postbutton').click();
+          browser.pause(wait);
+          browser.assertExpectedRequestsOnly();
+          assert.throws(() => {
+              browser.assertRequests();
+          }, /Expected\s\d\srequests\sbut\swas\s\d/);
+      });
+
+      it('can validate only the expected requests, in order (explicit)', () => {
+          browser.url('/multiple_methods.html');
+          browser.setupInterceptor();
+          browser.expectRequest('GET', '/get.json', 200);
+          browser.expectRequest('POST', '/post.json', 200);
+          $('#getbutton').click();
+          browser.pause(wait);
+          $('#postbutton').click();
+          browser.pause(wait);
+          // The next two are not needed, but adding extra clicks to prove we can validate partial set
+          $('#getbutton').click();
+          browser.pause(wait);
+          $('#postbutton').click();
+          browser.pause(wait);
+          browser.assertExpectedRequestsOnly(true);
+          assert.throws(() => {
+              browser.assertRequests();
+          }, /Expected\s\d\srequests\sbut\swas\s\d/);
+      });
+
+      it('can validate only the expected requests, in any order', () => {
+          browser.url('/multiple_methods.html');
+          browser.setupInterceptor();
+          browser.expectRequest('GET', '/get.json', 200);
+          browser.expectRequest('POST', '/post.json', 200);
+          $('#postbutton').click();
+          browser.pause(wait);
+          $('#postbutton').click();
+          browser.pause(wait);
+          $('#getbutton').click();
+          browser.pause(wait);
+          $('#getbutton').click();
+          browser.pause(wait);
+          browser.assertExpectedRequestsOnly(false);
+          assert.throws(() => {
+              browser.assertRequests();
+          }, /Expected\s\d\srequests\sbut\swas\s\d/);
+      });
   });
 
   describe('fetch API', () => {
@@ -228,6 +290,7 @@ describe('webdriverajax', function testSuite() {
       $('#fetchbutton').click();
       browser.pause(wait);
       browser.assertRequests();
+      browser.assertExpectedRequestsOnly();
     });
 
     it('can access a certain request', () => {


### PR DESCRIPTION
### Summary

In a more complex application, you may have many calls going on in the background, perhaps asynchronously, and being able to specify the order and number of these requests might be problematic.

There are also cases where you might be interested in just validating that a particular call happened (say, a background, async tracking call), but the core of the application (along with its API calls by proxy) will be validated via the UI.

This PR adds the ability to validate only the requests you specify in your `expectRequest` directives, without having to map out all the network requests that might happen around that.

Also add a couple of helper methods to access and reset `expectedRequests` should you wish to do so