### PR TITLE
Default to empty array when getting requests

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -196,9 +196,9 @@ var interceptor = {
     var requests
 
     if (window.sessionStorage && window.sessionStorage.getItem) {
-      requests = getFromSessionStorage()
+      requests = getFromSessionStorage() || []
     } else {
-      requests = window[NAMESPACE].requests
+      requests = window[NAMESPACE].requests || []
     }
 
     function getFromSessionStorage() {


### PR DESCRIPTION
When there were no requests made, the value returned from the interceptor would be `undefined`, but instead we would like to return an empty array.

This should fix #77.
