### PR TITLE
Sync-Async adaptive typings

### DIFF
--- a/types/wdio-intercept-service.d.ts
+++ b/types/wdio-intercept-service.d.ts
@@ -28,21 +28,25 @@ declare namespace WdioInterceptorService {
     }
   }
 }
+/**
+ * Convert T to T or Promise<T> depending if `@wdio/sync` is being used or not.
+ */
+type AsyncSync<T> = WebdriverIO.BrowserObject extends WebDriver.Client ? T : Promise<T>
 
 declare module WebdriverIO {
   interface Browser {
-    setupInterceptor: () => Promise<void>
+    setupInterceptor: () => AsyncSync<void>
     expectRequest: (
       method: WdioInterceptorService.HTTPMethod,
       url: string | RegExp,
       statusCode: number,
-    ) => Promise<BrowserObject>
-    assertRequests: () => Promise<BrowserObject>
-    assertExpectedRequestsOnly: (inOrder?: boolean) => Promise<BrowserObject>
-    resetExpectations: () => Promise<BrowserObject>
-    getExpectations: () => Promise<WdioInterceptorService.ExpectedRequest[]>
-    getRequest: (index: number) => Promise<WdioInterceptorService.InterceptedRequest>
-    getRequests: () => Promise<WdioInterceptorService.InterceptedRequest[]>
+    ) => AsyncSync<BrowserObject>
+    assertRequests: () => AsyncSync<BrowserObject>
+    assertExpectedRequestsOnly: (inOrder?: boolean) => AsyncSync<BrowserObject>
+    resetExpectations: () => AsyncSync<BrowserObject>
+    getExpectations: () => AsyncSync<WdioInterceptorService.InterceptedRequest[]>
+    getRequest: (index: number) => AsyncSync<WdioInterceptorService.InterceptedRequest>
+    getRequests: () => AsyncSync<WdioInterceptorService.InterceptedRequest[]>
   }
 }
 

--- a/types/wdio-intercept-service.d.ts
+++ b/types/wdio-intercept-service.d.ts
@@ -31,18 +31,18 @@ declare namespace WdioInterceptorService {
 
 declare module WebdriverIO {
   interface Browser {
-    setupInterceptor: () => void
+    setupInterceptor: () => Promise<void>
     expectRequest: (
       method: WdioInterceptorService.HTTPMethod,
       url: string | RegExp,
       statusCode: number,
-    ) => BrowserObject
-    assertRequests: () => BrowserObject
-    assertExpectedRequestsOnly: (inOrder?: boolean) => BrowserObject
-    resetExpectations: () => BrowserObject
-    getExpectations: () => WdioInterceptorService.ExpectedRequest[]
-    getRequest: (index: number) => WdioInterceptorService.InterceptedRequest
-    getRequests: () => WdioInterceptorService.InterceptedRequest[]
+    ) => Promise<BrowserObject>
+    assertRequests: () => Promise<BrowserObject>
+    assertExpectedRequestsOnly: (inOrder?: boolean) => Promise<BrowserObject>
+    resetExpectations: () => Promise<BrowserObject>
+    getExpectations: () => Promise<WdioInterceptorService.ExpectedRequest[]>
+    getRequest: (index: number) => Promise<WdioInterceptorService.InterceptedRequest>
+    getRequests: () => Promise<WdioInterceptorService.InterceptedRequest[]>
   }
 }
 


### PR DESCRIPTION
### Current issue:

In async mode (so without `@wdio/sync`), the function are not await-able out of the box, at least not without some dirty casting.

#### Sync mode (before and after):
```typescript
browser.setupInterceptor();
```
### Async mode before: 
```typescript
await (browser.setupInterceptor() as unknown as Promise<void>);
```
Without the casting, the `await` would get ignored because the functio is strongly typed to a synchronous object.

### Async mode after:
```typescript
await browser.setupInterceptor();
```


~~Tested in asynchronous, will test in synchronous before removing the draft flag.~~
Tested and working, see: [louis-bompart/shiny-octo-guacamole](https://github.com/louis-bompart/shiny-octo-guacamole)