### PR TITLE
Support ArrayBuffer decoding

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -103,7 +103,7 @@ var interceptor = {
             method: lastMethod.toUpperCase(),
             headers: xhr.getAllResponseHeaders(),
             requestHeaders: lastRequestHeader,
-            body: decodeArrayBuffer(xhr),
+            body: parseBody(xhr),
             statusCode: xhr.status,
             requestBody: lastRequestBody
           };
@@ -113,7 +113,7 @@ var interceptor = {
       };
     }
 
-    function decodeArrayBuffer(xhr) {
+    function parseBody(xhr) {
       if (xhr.responseType === 'arraybuffer') {
         return new TextDecoder().decode(xhr.response);
       }

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -103,8 +103,7 @@ var interceptor = {
             method: lastMethod.toUpperCase(),
             headers: xhr.getAllResponseHeaders(),
             requestHeaders: lastRequestHeader,
-            // IE9 comp: need xhr.responseText
-            body: xhr.responseType === 'arraybuffer' ? new TextDecoder().decode(xhr.response) : xhr.response || xhr.responseText,
+            body: decodeArrayBuffer(xhr),
             statusCode: xhr.status,
             requestBody: lastRequestBody
           };
@@ -112,6 +111,14 @@ var interceptor = {
         });
         return xhr;
       };
+    }
+
+    function decodeArrayBuffer(xhr) {
+      if (xhr.responseType === 'arraybuffer') {
+        return new TextDecoder().decode(xhr.response);
+      }
+      // IE9 comp: need xhr.responseText
+      return xhr.response || xhr.responseText;
     }
 
     function parseHeaders(headers) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -104,7 +104,7 @@ var interceptor = {
             headers: xhr.getAllResponseHeaders(),
             requestHeaders: lastRequestHeader,
             // IE9 comp: need xhr.responseText
-            body: xhr.response || xhr.responseText,
+            body: xhr.responseType === 'arraybuffer' ? new TextDecoder().decode(xhr.response) : xhr.response || xhr.responseText,
             statusCode: xhr.status,
             requestBody: lastRequestBody
           };


### PR DESCRIPTION
This PR will add support for ArrayBuffer decoding for media types that are not being read as plain text as I described on https://github.com/chmanie/wdio-intercept-service/issues/119
The change proposed would help the interceptor service to read more media types like VTT.